### PR TITLE
Adds partitioning branch for Python dbt models

### DIFF
--- a/dbt/include/spark/macros/materializations/table.sql
+++ b/dbt/include/spark/macros/materializations/table.sql
@@ -90,7 +90,11 @@ else:
   msg = f"{type(df)} is not a supported type for dbt Python materialization"
   raise Exception(msg)
 
-df.write.mode("overwrite").format("iceberg").option("overwriteSchema", "true").saveAsTable("{{ target_relation }}")
+{% if partition_cols() -%}
+  df.write.mode("overwrite").format("iceberg").partitionBy('{{ partition_cols() | trim }}'.strip("()").split(",")).option("overwriteSchema", "true").saveAsTable("{{ target_relation }}")
+{% else -%}
+  df.write.mode("overwrite").format("iceberg").option("overwriteSchema", "true").saveAsTable("{{ target_relation }}")
+{%- endif %}
 {%- endmacro -%}
 
 {%macro py_script_comment()%}


### PR DESCRIPTION
This PR changes the behavior of dbt Python models to emit tables that are partitioned based on model configurations passed in by the user. The default behavior is to not pass partition information but it made reading large tables with Python slow.

The code calls partition_cols() which is populated by the executing model's YML file, we use partition_cols() because it's formatted for strings and lists as input and saves us the trouble of dealing with those types. Checking the existence of a value (none being no partitioning was requested by the model), we then write it out to a table using the PySpark dataframe API because this macro runs exclusively in Python mode and cannot be coerced to invoke SQL jinja easily.